### PR TITLE
included curl errors

### DIFF
--- a/search.SS.class.php
+++ b/search.SS.class.php
@@ -117,8 +117,14 @@ class SS_search{
 
 		$output=curl_exec($ch);
 
-		curl_close($ch);
+		// Check for errors and display the error message
+		if($errno = curl_errno($ch)) {
+			$error_message = curl_strerror($errno);
+			echo "cURL error ({$errno}):\n {$error_message}";
+			exit(1);
+		}
 
+		curl_close($ch);
 		return explode("\r\n\r\n", $output, 2);
 	}
 


### PR DESCRIPTION
## Curl error messages
In my computer, cUrl was not working properly so I decided to include some useful debugging code to let the users know if something has gone wrong with curl, one example of the new output would be:
```
cURL error (60):
Peer certificate cannot be authenticated with given CA certificates
```
This code was adapted from [php.net](http://php.net/manual/en/function.curl-strerror).